### PR TITLE
Auto deploy gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   buildGodoc:
     branches:
       only:
-        - develop
+        - add-ghpages-scripts
     working_directory: /tmp
     docker:
       - image: golang:1.12.5
@@ -25,7 +25,7 @@ jobs:
   deployGhpages:
     branches:
       only:
-        - develop
+        - add-ghpages-scripts
     docker:
       - image: node:11
     steps:


### PR DESCRIPTION
Deploy gh-pages automatically using CircleCI

## Changed
### Created
- .circleci/config.yml
- gh-pages/buildGodoc.sh
- gh-pages/deploy.js
- gh-pages/deploy.sh
- gh-pages/dist/index.html
- gh-pages/package-lock.json
- gh-pages/package.json

### Modified
 - .gitignore

## Note
CircleCIの導入頼みます🙏
こちらではCircleCIのコンフィグの確認に限界があるので、そちらで確認をお願いします。