### PR TITLE
Check password retype before sending signup request and init this.server

### DIFF
--- a/frontend/src/components/login.vue
+++ b/frontend/src/components/login.vue
@@ -62,6 +62,7 @@ export default {
     login: function() {
       var self = this;
       this.flag++;
+      this.server = "";
       if (this.loginId !== '' && this.loginPass !== '' && this.loginId.length <= 64 && this.loginPass.length <= 64) {
         var data = {name : this.loginId, password : this.loginPass };
         axios.post('/api/v1/user/login', data)

--- a/frontend/src/components/signup.vue
+++ b/frontend/src/components/signup.vue
@@ -69,7 +69,9 @@ export default {
     signup: function() {
       var self = this;
       this.flag++;
-      if (this.signupId !== '' && this.signupPass !== '' && this.signupId.length <= 64 && this.signupPass.length <= 64) {
+      this.server = "";
+      if (this.signupId !== '' && this.signupPass !== '' && this.signupId.length <= 64 && this.signupPass.length <= 64 &&
+          this.signupPass == this.signupPassRetype) {
         var data = {name : this.signupId, password : this.signupPass };
         axios.post('/api/v1/user/new', data)
           .then(response => {


### PR DESCRIPTION
パスワード再入力の検査がサーバへのサインアップ要求前になされていないため、エラーメッセージは出るものの実質的に検査していないことになっている。また、サーバからのエラーメッセージのキャッシュを毎回リセットするように変更。 this fixes #41

## Changed
### Modified
 - ./frontend/src/components/login.vue
 - ./frontend/src/components/signup.vue

## Note
あとでコンフリクトが起こると思うけど、気付いた時に修正したかったので、あとで解消しましょう。