### PR TITLE
TagListにBootStrapを適用

### DIFF
--- a/frontend/src/components/tag-list.vue
+++ b/frontend/src/components/tag-list.vue
@@ -1,12 +1,12 @@
 <template lang="html">
-  <select v-model="selected">
-    <option v-bind:value="0">全てのタグ</option>
-    <option v-for="option in headLabels"
+  <b-form-select v-model="selected">
+    <option v-bind:value="0">タグを選択</option>
+    <option v-for="option in tags"
       v-bind:value="option.Id"
       v-bind:key="option.Id">
       {{ option.name }}
     </option>
-  </select>
+  </b-form-select>
 </template>
 
 <script>
@@ -17,19 +17,22 @@ export default {
     }
   },
   computed: {
-    headLabels(){
+    tags(){
       return this.$store.state.tag_list
     }
   },
   mounted: function() {
-    this.$store.dispatch("getTagList")
-    this.$store.dispatch("tagSelect", this.selected)
+    this.$store.dispatch('getTagList')
     this.selected = this.$store.state.select_tag
+    if(this.selected == null){
+      this.selected = 0
+      this.$store.dispatch('tagSelect', 0)
+    }
   },
   watch: {
     selected() {
-      this.$store.dispatch("tagSelect", this.selected)
-      this.$store.dispatch("getMonoList", {name:null, tagId:this.selected})
+      this.$store.dispatch('tagSelect', this.selected)
+      this.$store.dispatch('getMonoList', {name:null, tagId:this.selected})
     }
   }
 }


### PR DESCRIPTION
<!-- このPullRequestの概要を1,2行で書く -->
タグリストの描画に関しての処理
`select` タグを `b-form-select` タグに変更．
「全てのタグ」を「タグを選択」に変更
`this.$store.state.select_tag` がnullの際に0を代入する処理を記述

## Changed
### Modified
<!-- 編集したファイル群を列挙する -->
 - frontend/src/components/tag-list.vue

## Note
<!-- コメント等, 伝えたいこと, 書きたいことがあれば書く -->
 - 表示が気に入らなかったのと，どこで追加したか分からなくなるのが嫌だったのでブランチ切ってPR投げました．
 - `npm run serve` での動作は確認しています
