### PR TITLE
Add createMono button & editMono button

### DIFF
--- a/frontend/src/components/mono-list.vue
+++ b/frontend/src/components/mono-list.vue
@@ -1,7 +1,7 @@
 <template lang="html">
   <div>
     <table striped>
-      <tr v-for="item in list" :key="item.Id", @click="editMono(item.Id)">
+      <tr v-for="item in list" :key="item.Id" @click="editMono(item.Id)">
         <td>
           {{item.name}}
         </td>


### PR DESCRIPTION
<!-- このPullRequestの概要を1,2行で書く -->
mono-list.vueに要素追加ボタン(+)を実装．/mono/newに飛ぶ．
リストもクリックすることで/mono/:idに飛ばす実装をしたが，そちらの挙動は確認できていない

## Changed
### Modified
<!-- 編集したファイル群を列挙する -->
 - frontend/src/components/mono-list.vue

## Note
<!-- コメント等, 伝えたいこと, 書きたいことがあれば書く -->
 - 多分この実装が一番速いと思います
