### PR TITLE
hide hashedpass from CheckLogin function's return value

### DIFF
--- a/backend/internal/userHelper.go
+++ b/backend/internal/userHelper.go
@@ -63,7 +63,7 @@ func CheckLogin(c *gin.Context) (User, error) {
 			"message": err.Error(),
 		})
 	}
-	return user, err
+	return User{ ID: user.ID, Name: user.Name }, err
 }
 
 /*


### PR DESCRIPTION
CheckLogin関数がHashedPassを返さないようにする

## Changed
### Modified
 - backend/internal/userHelper.go