### PR TITLE
#88での変更の中に表面化しないバグを発見

### DIFF
--- a/frontend/src/components/errorModal.vue
+++ b/frontend/src/components/errorModal.vue
@@ -25,7 +25,7 @@
       }
     },
     mounted:function(){
-      this.$store.commit('setErrorModalStatus', false)
+      this.$store.commit('hideError')
     }
   }
 </script>


### PR DESCRIPTION
モーダルウィンドウの初期表示を明示的にfalseにするコードの呼び出しが過去のコミットで削除したものを呼び出していた．consoleでエラーを吐いていたことから発見，修正した

<!-- このPullRequestの概要を1,2行で書く -->

## Changed
### Modified
<!-- 編集したファイル群を列挙する -->
 - errorModal.vue

## Note
<!-- コメント等, 伝えたいこと, 書きたいことがあれば書く -->
 - 
